### PR TITLE
Populate self._devices_by_nwk dict with DB data.

### DIFF
--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -17,7 +17,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         api.set_application(self)
 
         self._pending = {}
-        self._devices_by_nwk = {}
+        self._devices_by_nwk = {d.nwk: d.ieee for a, d in self.devices.items()}
 
         self._nwk = 0
 


### PR DESCRIPTION
Upon HA restart, the `self._devices_by_nwk` is empty and we can't send any request to the device, not until we hear back from the device 1st. And I think this is the cause for #12 

```
2018-10-12 19:01:37 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: service=turn_on, domain=switch, service_data=entity_id=switch.osram_plug_01_00a6af65_3, service_call_id=7a64e550da4744698b399e6342a028a5>
2018-10-12 19:01:37 DEBUG (MainThread) [zigpy_xbee.zigbee.application] Zigbee request seq 7
2018-10-12 19:01:37 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event service_executed[L]: service_call_id=7a64e550da4744698b399e6342a028a5>
2018-10-12 19:01:44 INFO (MainThread) [homeassistant.components.http.view] Serving /states to 192.168.192.153 (auth: False)
2018-10-12 19:01:44 ERROR (Thread-8) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "/home/lex/lex/src/ac-hass/homeassistant/helpers/service.py", line 224, in _handle_service_platform_call
    await getattr(entity, func)(**data)
  File "/home/lex/lex/src/ac-hass/homeassistant/components/switch/zha.py", line 71, in async_turn_on
    res = await self._endpoint.on_off.on()
  File "/home/lex/lex/src/zigpy/zigpy/device.py", line 91, in request
    expect_reply=expect_reply,
  File "/home/lex/lex/src/zigpy-xbee/zigpy_xbee/zigbee/application.py", line 71, in request
    self._devices_by_nwk[nwk],
KeyError: 51474
```

So we either can update `self._devices_by_nwk` with data from application database or maybe better change
```
diff --git a/zigpy_xbee/zigbee/application.py b/zigpy_xbee/zigbee/application.py
index 2b4fd18..b035ed2 100644
--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -68,7 +68,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         self._pending[sequence] = reply_fut
         self._api._seq_command(
             'tx_explicit',
-            self._devices_by_nwk[nwk],
+            self.get_device(nwk=nwk).ieee,
             nwk,
             src_ep,
             dst_ep,
```
