### PR TITLE
Retain settings after xbee resets

### DIFF
--- a/zigpy_xbee/api.py
+++ b/zigpy_xbee/api.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 # https://www.digi.com/resources/documentation/digidocs/PDFs/90000976.pdf
 COMMANDS = {
     'at': (0x08, (t.uint8_t, t.ATCommand, t.Bytes), 0x88),
-    'queued_at': (0x09, (), None),
+    'queued_at': (0x09, (t.uint8_t, t.ATCommand, t.Bytes), 0x88),
     'remote_at': (0x17, (), None),
     'tx': (0x10, (), None),
     'tx_explicit': (0x11, (t.uint8_t, t.EUI64, t.uint16_t, t.uint8_t, t.uint8_t, t.uint16_t, t.uint16_t, t.uint8_t, t.uint8_t, t.Bytes), None),
@@ -185,6 +185,16 @@ class XBee:
     def _seq_command(self, name, *args):
         LOGGER.debug("Sequenced command: %s %s", name, args)
         return self._command(name, self._seq, *args)
+
+    def _queued_at(self, name, *args):
+        LOGGER.debug("Queue AT command: %s %s", name, args)
+        data = t.serialize(args, (AT_COMMANDS[name], ))
+        return self._command(
+            'queued_at',
+            self._seq,
+            name.encode('ascii'),
+            data,
+        )
 
     def _at_command(self, name, *args):
         LOGGER.debug("AT command: %s %s", name, args)

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -43,25 +43,36 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if auto_form and not (association_state == 0 and self._nwk == 0):
             await self.form_network()
 
+        ce = await self._api._at_command('CE')
+        LOGGER.debug("Coordinator %s", 'enabled' if ce else 'disabled')
+        nj = await self._api._at_command('NJ')
+        LOGGER.debug("Join permited time %is", nj)
+        id = await self._api._at_command('ID')
+        LOGGER.debug("Extended PAN ID: 0x%016x", id)
+        id = await self._api._at_command('OP')
+        LOGGER.debug("Operating Extended PAN ID: 0x%016x", id)
+        id = await self._api._at_command('OI')
+        LOGGER.debug("PAN ID: 0x%04x", id)
+
     async def force_remove(self, dev):
         """Forcibly remove device from NCP."""
         pass
 
     async def form_network(self, channel=15, pan_id=None, extended_pan_id=None):
         LOGGER.info("Forming network on channel %s", channel)
-        await self._api._at_command('AI')
-
         scan_bitmask = 1 << (channel - 11)
-        await self._api._at_command('ZS', 2)
-        await self._api._at_command('SC', scan_bitmask)
-        await self._api._at_command('EE', 1)
-        await self._api._at_command('EO', 2)
-        await self._api._at_command('NK', 0)
-        await self._api._at_command('KY', b'ZigBeeAlliance09')
-        await self._api._at_command('WR')
-        await self._api._at_command('AC')
-        await self._api._at_command('CE', 1)
+        await self._api._queued_at('ZS', 2)
+        await self._api._queued_at('SC', scan_bitmask)
+        await self._api._queued_at('EE', 1)
+        await self._api._queued_at('EO', 2)
+        await self._api._queued_at('NK', 0)
+        await self._api._queued_at('KY', b'ZigBeeAlliance09')
+        await self._api._queued_at('CE', 1)
+        await self._api._queued_at('NJ', 0)
+        await self._api._queued_at('AC')
+        await self._api._queued_at('WR')
 
+        await asyncio.sleep(0.2)
         self._nwk = await self._api._at_command('MY')
 
     @zigpy.util.retryable_request

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -17,7 +17,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         api.set_application(self)
 
         self._pending = {}
-        self._devices_by_nwk = {}
+        self._devices_by_nwk = {d.nwk: d.ieee for a, d in self.devices.items()}
 
         self._nwk = 0
 

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -43,6 +43,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if auto_form and not (association_state == 0 and self._nwk == 0):
             await self.form_network()
 
+    async def force_remove(self, dev):
+        """Forcibly remove device from NCP."""
+        pass
+
     async def form_network(self, channel=15, pan_id=None, extended_pan_id=None):
         LOGGER.info("Forming network on channel %s", channel)
         await self._api._at_command('AI')


### PR DESCRIPTION
This fixes #12  In my case every time XBee was powercycled, controller was forming a new network effectively erasing all joined devices.