### PR TITLE
Add unit tests.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,182 @@
+import asyncio
+from unittest import mock
+
+import pytest
+
+from zigpy_xbee import api as xbee_api
+from zigpy_xbee import types as t
+from zigpy_xbee import uart
+
+
+@pytest.fixture
+def api():
+    api = xbee_api.XBee()
+    api._uart = mock.MagicMock()
+    return api
+
+
+@pytest.mark.asyncio
+async def test_connect(monkeypatch):
+    api = xbee_api.XBee()
+    dev = mock.MagicMock()
+    monkeypatch.setattr(
+        uart, 'connect',
+        mock.MagicMock(side_effect=asyncio.coroutine(mock.MagicMock())))
+    await api.connect(dev, 115200)
+
+
+def test_close(api):
+    api._uart.close = mock.MagicMock()
+    api.close()
+    assert api._uart.close.call_count == 1
+
+
+def test_commands():
+    import string
+    anum = string.ascii_letters + string.digits + '_'
+
+    for cmd_name, cmd_opts in xbee_api.COMMANDS.items():
+        assert isinstance(cmd_name, str) is True
+        assert all([c in anum for c in cmd_name]), cmd_name
+        assert len(cmd_opts) == 3
+        cmd_id, schema, reply = cmd_opts
+        assert isinstance(cmd_id, int) is True
+        assert isinstance(schema, tuple) is True
+        assert reply is None or isinstance(reply, int)
+
+
+@pytest.mark.asyncio
+async def test_command(api):
+    def mock_api_frame(name, *args):
+        c = xbee_api.COMMANDS[name]
+        return mock.sentinel.api_frame_data, c[2]
+    api._api_frame = mock.MagicMock(side_effect=mock_api_frame)
+    api._uart.send = mock.MagicMock()
+
+    for cmd_name, cmd_opts in xbee_api.COMMANDS.items():
+        cmd_id, schema, expect_reply = cmd_opts
+        ret = api._command(cmd_name, mock.sentinel.cmd_data)
+        if expect_reply:
+            assert asyncio.isfuture(ret) is True
+            ret.cancel()
+        else:
+            assert ret is None
+        assert api._api_frame.call_count == 1
+        assert api._api_frame.call_args[0][0] == cmd_name
+        assert api._api_frame.call_args[0][1] == mock.sentinel.cmd_data
+        assert api._uart.send.call_count == 1
+        assert api._uart.send.call_args[0][0] == mock.sentinel.api_frame_data
+        api._api_frame.reset_mock()
+        api._uart.send.reset_mock()
+
+
+def test_seq_command(api):
+    api._command = mock.MagicMock()
+    api._seq = mock.sentinel.seq
+    api._seq_command(mock.sentinel.cmd_name, mock.sentinel.args)
+    assert api._command.call_count == 1
+    assert api._command.call_args[0][0] == mock.sentinel.cmd_name
+    assert api._command.call_args[0][1] == mock.sentinel.seq
+    assert api._command.call_args[0][2] == mock.sentinel.args
+
+
+def test_at_command(api, monkeypatch):
+    monkeypatch.setattr(t, 'serialize', mock.MagicMock(return_value=mock.sentinel.serialize))
+    api._command = mock.MagicMock()
+    api._seq = mock.sentinel.seq
+
+    for at_cmd in xbee_api.AT_COMMANDS:
+        api._at_command(at_cmd, mock.sentinel.args)
+        assert t.serialize.call_count == 1
+        assert api._command.call_count == 1
+        assert api._command.call_args[0][0] == 'at'
+        assert api._command.call_args[0][1] == mock.sentinel.seq
+        assert api._command.call_args[0][2] == at_cmd.encode('ascii')
+        assert api._command.call_args[0][3] == mock.sentinel.serialize
+        t.serialize.reset_mock()
+        api._command.reset_mock()
+
+
+def test_api_frame(api):
+    ieee = t.EUI64([t.uint8_t(a) for a in range(0, 8)])
+    for cmd_name, cmd_opts in xbee_api.COMMANDS.items():
+        cmd_id, schema, repl = cmd_opts
+        if schema:
+            args = [ieee if isinstance(a(), t.EUI64) else a() for a in schema]
+            frame, repl = api._api_frame(cmd_name, *args)
+        else:
+            frame, repl = api._api_frame(cmd_name)
+
+
+def test_frame_received(api, monkeypatch):
+    monkeypatch.setattr(t, 'deserialize', mock.MagicMock(
+        return_value=(mock.sentinel.deserialize_data, b'')))
+    my_handler = mock.MagicMock()
+
+    for cmd, cmd_opts in xbee_api.COMMANDS.items():
+        cmd_id = cmd_opts[0]
+        payload = b'\x01\x02\x03\x04'
+        data = cmd_id.to_bytes(1, 'big') + payload
+        setattr(api, '_handle_{}'.format(cmd), my_handler)
+        api.frame_received(data)
+        assert t.deserialize.call_count == 1
+        assert t.deserialize.call_args[0][0] == payload
+        assert my_handler.call_count == 1
+        assert my_handler.call_args[0][0] == mock.sentinel.deserialize_data
+        t.deserialize.reset_mock()
+        my_handler.reset_mock()
+
+
+def _handle_at_response(api, tsn, status, at_response=b''):
+    data = (tsn, 'AI'.encode('ascii'), status, at_response)
+    response = asyncio.Future()
+    api._awaiting[tsn] = (response, )
+    api._handle_at_response(data)
+    return response
+
+
+def test_handle_at_response_none(api):
+    tsn = 123
+    fut = _handle_at_response(api, tsn, 0)
+    assert fut.done() is True
+    assert fut.result() is None
+    assert fut.exception() is None
+
+
+def test_handle_at_response_data(api):
+    tsn = 123
+    status, response = 0, 0x23
+    fut = _handle_at_response(api, tsn, status, [response])
+    assert fut.done() is True
+    assert fut.result() == response
+    assert fut.exception() is None
+
+
+def test_handle_at_response_error(api):
+    tsn = 123
+    status, response = 1, 0x23
+    fut = _handle_at_response(api, tsn, status, [response])
+    assert fut.done() is True
+    assert fut.exception() is not None
+
+
+def test_handle_modem_status(api):
+    s = mock.sentinel
+    data = [s.modem_status, s.extra_1, s.extra_2, s.extra_3]
+    api._app = mock.MagicMock()
+    api._app.handle_modem_status = mock.MagicMock()
+    api._handle_modem_status(data)
+    assert api._app.handle_modem_status.call_count == 1
+    assert api._app.handle_modem_status.call_args[0][0] == mock.sentinel.modem_status
+
+
+def test_handle_explicit_rx_indicator(api):
+    data = b'\x00\x01\x02\x03\x04\x05\x06\x07'
+    api._app = mock.MagicMock()
+    api._app.handle_rx = mock.MagicMock()
+    api._handle_explicit_rx_indicator(data)
+    assert api._app.handle_rx.call_count == 1
+
+
+def test_handle_tx_status(api):
+    api._handle_tx_status(b'\x01\x02\x03\x04')

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,7 +1,9 @@
+import asyncio
 from unittest import mock
 
 import pytest
 
+from zigpy.types import EUI64
 from zigpy_xbee.api import XBee
 from zigpy_xbee.zigbee.application import ControllerApplication
 
@@ -55,6 +57,23 @@ def test_rx(app):
     ), )
 
 
+def test_rx_nwk_0000(app):
+    app._handle_reply = mock.MagicMock()
+    app.handle_message = mock.MagicMock()
+    app.handle_rx(
+        b'\x01\x02\x03\x04\x05\x06\x07\x08',
+        0x0000,
+        mock.sentinel.src_ep,
+        mock.sentinel.dst_ep,
+        mock.sentinel.cluster_id,
+        mock.sentinel.profile_id,
+        mock.sentinel.rxopts,
+        b''
+    )
+    assert app.handle_message.call_count == 0
+    assert app._handle_reply.call_count == 0
+
+
 def test_rx_reply(app):
     app._handle_reply = mock.MagicMock()
     _test_rx(app, mock.MagicMock(), (1, 2, True, []))
@@ -82,3 +101,150 @@ def test_rx_failed_deserialize(app, caplog):
 
     assert app._handle_reply.call_count == 0
     assert app.handle_message.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_form_network(app):
+    async def mock_at_command(cmd, *args):
+        if cmd == 'MY':
+            return mock.sentinel.ncp_nwk
+        return None
+
+    app._api._at_command = mock.MagicMock(spec=XBee._at_command,
+                                          side_effect=mock_at_command)
+    await app.form_network()
+    assert app._api._at_command.call_count > 8
+    assert app._nwk == mock.sentinel.ncp_nwk
+
+
+async def _test_startup(app, ai_status=0xff, auto_form=False):
+    ai_tries = 5
+
+    async def _at_command_mock(cmd, *args):
+        nonlocal ai_tries
+        ai_tries -= 1
+        return {
+            'SH': 0x01020304,
+            'SL': 0x05060708,
+            'MY': 0xfffe if ai_status else 0x0000,
+            'AI': ai_status if ai_tries < 0 else 0xff
+        }.get(cmd, None)
+
+    app._api._at_command = mock.MagicMock(spec=XBee._at_command,
+                                          side_effect=_at_command_mock)
+    app.form_network = mock.MagicMock(
+        side_effect=asyncio.coroutine(mock.MagicMock()))
+
+    await app.startup(auto_form=auto_form)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_startup_ai(app):
+    auto_form = True
+    await _test_startup(app, 0x00, auto_form)
+    assert app._nwk == 0x0000
+    assert app._ieee == EUI64(range(1, 9))
+    assert app.form_network.call_count == 0
+
+    auto_form = False
+    await _test_startup(app, 0x00, auto_form)
+    assert app._nwk == 0x0000
+    assert app._ieee == EUI64(range(1, 9))
+    assert app.form_network.call_count == 0
+
+    auto_form = True
+    await _test_startup(app, 0x06, auto_form)
+    assert app._nwk == 0xfffe
+    assert app._ieee == EUI64(range(1, 9))
+    assert app.form_network.call_count == 1
+
+    auto_form = False
+    await _test_startup(app, 0x06, auto_form)
+    assert app._nwk == 0xfffe
+    assert app._ieee == EUI64(range(1, 9))
+    assert app.form_network.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_permit(app):
+    app._api._at_command = mock.MagicMock(
+        side_effect=asyncio.coroutine(mock.MagicMock()))
+    time_s = 30
+    await app.permit(time_s)
+    assert app._api._at_command.call_count == 3
+    assert app._api._at_command.call_args_list[0][0][1] == time_s
+
+
+async def _test_request(app, do_reply=True, expect_reply=True, **kwargs):
+    seq = 123
+    nwk = 0x2345
+    app._devices_by_nwk[nwk] = 0x22334455
+
+    def _mock_seq_command(cmdname, ieee, nwk, src_ep, dst_ep, cluster,
+                          profile, radius, options, data):
+        if expect_reply:
+            if do_reply:
+                app._pending[seq].set_result(mock.sentinel.reply_result)
+
+    app._api._seq_command = mock.MagicMock(side_effect=_mock_seq_command)
+    return await app.request(nwk, 0x0260, 1, 2, 3, seq, [4, 5, 6], **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_request_with_reply(app):
+    assert await _test_request(app, True, True) == mock.sentinel.reply_result
+
+
+@pytest.mark.asyncio
+async def test_request_no_reply(app):
+    with pytest.raises(asyncio.TimeoutError):
+        await _test_request(app, False, True, tries=2, timeout=0.1)
+
+
+def _handle_reply(app, tsn):
+    app.handle_message = mock.MagicMock()
+    return app._handle_reply(
+        mock.sentinel.device,
+        mock.sentinel.profile,
+        mock.sentinel.cluster,
+        mock.sentinel.src_ep,
+        mock.sentinel.dst_ep,
+        tsn,
+        mock.sentinel.command_id,
+        mock.sentinel.args
+    )
+
+
+def test_handle_reply(app):
+    tsn = 123
+    fut = asyncio.Future()
+    app._pending[tsn] = fut
+    _handle_reply(app, tsn)
+
+    assert app.handle_message.call_count == 0
+    assert fut.result() == mock.sentinel.args
+
+
+def test_handle_reply_dup(app):
+    tsn = 123
+    fut = asyncio.Future()
+    app._pending[tsn] = fut
+    fut.set_result(mock.sentinel.reply_result)
+    _handle_reply(app, tsn)
+    assert app.handle_message.call_count == 0
+
+
+def test_handle_reply_unexpected(app):
+    tsn = 123
+    _handle_reply(app, tsn)
+    assert app.handle_message.call_count == 1
+    assert app.handle_message.call_args[0][0] == mock.sentinel.device
+    assert app.handle_message.call_args[0][1] is True
+    assert app.handle_message.call_args[0][2] == mock.sentinel.profile
+    assert app.handle_message.call_args[0][3] == mock.sentinel.cluster
+    assert app.handle_message.call_args[0][4] == mock.sentinel.src_ep
+    assert app.handle_message.call_args[0][5] == mock.sentinel.dst_ep
+    assert app.handle_message.call_args[0][6] == tsn
+    assert app.handle_message.call_args[0][7] == mock.sentinel.command_id
+    assert app.handle_message.call_args[0][8] == mock.sentinel.args

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -1,20 +1,125 @@
 from unittest import mock
 
-from zigpy_xbee.uart import Gateway
+import pytest
+import serial_asyncio
+
+from zigpy_xbee import uart
 
 
-def test_extract():
-    gateway = Gateway(mock.MagicMock())
-    gateway._buffer = b'\x7E\x00\x02\x23\x7D\x31\xCBextra'
-    frame = gateway._extract_frame()
+@pytest.mark.asyncio
+async def test_connect_uart(monkeypatch):
+    api = mock.MagicMock()
+    portmock = mock.MagicMock()
+
+    async def mock_conn(loop, protocol_factory, **kwargs):
+        protocol = protocol_factory()
+        loop.call_soon(protocol.connection_made, None)
+        return None, protocol
+    monkeypatch.setattr(serial_asyncio, 'create_serial_connection', mock_conn)
+
+    await uart.connect(portmock, 57600, api)
+
+
+@pytest.fixture
+def gw():
+    gw = uart.Gateway(mock.MagicMock())
+    gw._transport = mock.MagicMock()
+    gw._transport.serial.BAUDRATES = serial_asyncio.serial.Serial.BAUDRATES
+    return gw
+
+
+@pytest.mark.asyncio
+async def test_connect(monkeypatch):
+    api = mock.MagicMock()
+    portmock = mock.MagicMock()
+
+    async def mock_conn(loop, protocol_factory, **kwargs):
+        protocol = protocol_factory()
+        loop.call_soon(protocol.connection_made, None)
+        return None, protocol
+    monkeypatch.setattr(serial_asyncio, 'create_serial_connection', mock_conn)
+
+    await uart.connect(portmock, 57600, api)
+
+
+def test_close(gw):
+    gw.close()
+    assert gw._transport.close.call_count == 1
+
+
+def test_data_received_chunk_frame(gw):
+    data = b'~\x00\x07\x8b\x0e\xff\xfd\x00$\x02D'
+    gw.frame_received = mock.MagicMock()
+    gw.data_received(data[:-4])
+    assert gw.frame_received.call_count == 0
+    gw.data_received(data[-4:])
+    assert gw.frame_received.call_count == 1
+    assert gw.frame_received.call_args[0][0] == data[3:-1]
+
+
+def test_data_received_full_frame(gw):
+    data = b'~\x00\x07\x8b\x0e\xff\xfd\x00$\x02D'
+    gw.frame_received = mock.MagicMock()
+    gw.data_received(data)
+    assert gw.frame_received.call_count == 1
+    assert gw.frame_received.call_args[0][0] == data[3:-1]
+
+
+def test_data_received_incomplete_frame(gw):
+    data = b'~\x00\x07\x8b\x0e\xff\xfd'
+    gw.frame_received = mock.MagicMock()
+    gw.data_received(data)
+    assert gw.frame_received.call_count == 0
+
+
+def test_extract(gw):
+    gw._buffer = b'\x7E\x00\x02\x23\x7D\x31\xCBextra'
+    frame = gw._extract_frame()
     assert frame == b'\x23\x11'
-    assert gateway._buffer == b'extra'
+    assert gw._buffer == b'extra'
 
 
-def test_send():
-    gateway = Gateway(mock.MagicMock())
-    gateway._transport = mock.MagicMock()
-    gateway.send(b'\x23\x11')
-    assert gateway._transport.write.call_count == 1
+def test_extract_wrong_checksum(gw):
+    gw._buffer = b'\x7E\x00\x02\x23\x7D\x31\xCEextra'
+    frame = gw._extract_frame()
+    assert frame is None
+    assert gw._buffer == b'extra'
+
+
+def test_extract_checksum_none(gw):
+    data = b'\x7E\x00\x02\x23\x7D\x31'
+    gw._buffer = data
+    gw._checksum = lambda x: None
+    frame = gw._extract_frame()
+    assert frame is None
+    assert gw._buffer == data
+
+
+def test_extract_frame_len_none(gw):
+    data = b'\x7E'
+    gw._buffer = data
+    frame = gw._extract_frame()
+    assert frame is None
+    assert gw._buffer == data
+
+
+def test_extract_frame_no_start(gw):
+    data = b'\x00\x02\x23\x7D\x31'
+    gw._buffer = data
+    frame = gw._extract_frame()
+    assert frame is None
+    assert gw._buffer == data
+
+
+def test_frame_received(gw):
+    data = b'frame'
+    gw.frame_received(data)
+    assert gw._api.frame_received.call_count == 1
+    assert gw._api.frame_received.call_args[0][0] == data
+
+
+def test_send(gw):
+    gw.send(b'\x23\x11')
+    assert gw._transport.write.call_count == 1
     data = b'\x7E\x00\x02\x23\x7D\x31\xCB'
-    assert gateway._transport.write.called_once_with(data)
+    assert gw._transport.write.called_once_with(data)

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     coveralls
     pytest
     pytest-cov
+    pytest-asyncio
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
Add tests for application, api & uart modules. 
application.request fails a test, because current code leaks TSNs when there's a timeout receiving a reply, similar issue as https://github.com/zigpy/bellows/pull/132