### PR TITLE
Call Handle join when device changes nwk

### DIFF
--- a/zigpy_xbee/api.py
+++ b/zigpy_xbee/api.py
@@ -300,10 +300,10 @@ class XBee:
 
         for cmd in cmds:
             if await self.command_mode_at_cmd(cmd + '\r'):
-                    LOGGER.debug("Successfuly sent %s cmd", cmd)
+                LOGGER.debug("Successfuly sent %s cmd", cmd)
             else:
-                    LOGGER.debug("No response to %s cmd", cmd)
-                    return None
+                LOGGER.debug("No response to %s cmd", cmd)
+                return None
         return True
 
     async def init_api_mode(self):

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -129,9 +129,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         ember_ieee = zigpy.types.EUI64(src_ieee)
         if ember_ieee not in self.devices:
+            LOGGER.debug('New Device')
             self.handle_join(src_nwk, ember_ieee, 0)  # TODO: Parent nwk
         self._devices_by_nwk[src_nwk] = src_ieee
         device = self.get_device(ember_ieee)
+        if device.nwk != src_nwk:
+            LOGGER.debug('nwk changed')
+            self.handle_join(src_nwk, ember_ieee, 0)
 
         try:
             tsn, command_id, is_reply, args = self.deserialize(device, src_ep, cluster_id, data)

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -129,11 +129,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         ember_ieee = zigpy.types.EUI64(src_ieee)
         if ember_ieee not in self.devices:
-            LOGGER.debug('New Device')
             self.handle_join(src_nwk, ember_ieee, 0)  # TODO: Parent nwk       
         device = self.get_device(ember_ieee)
         if device.nwk != src_nwk:
-            LOGGER.debug('nwk changed')
             self.handle_join(src_nwk, ember_ieee, 0)
             self._devices_by_nwk.pop(device.nwk, None)
         self._devices_by_nwk[src_nwk] = src_ieee

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -144,11 +144,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             return
 
         ember_ieee = zigpy.types.EUI64(src_ieee)
-        if ember_ieee not in self.devices:
-            self.handle_join(src_nwk, ember_ieee, 0)  # TODO: Parent nwk       
+        if src_nwk not in self._devices_by_nwk:
+            self.handle_join(src_nwk, ember_ieee, 0)  # TODO: Parent nwk
         device = self.get_device(ember_ieee)
         if device.nwk != src_nwk:
-            self.handle_join(src_nwk, ember_ieee, 0)
             self._devices_by_nwk.pop(device.nwk, None)
         self._devices_by_nwk[src_nwk] = src_ieee
 

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -130,8 +130,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         ember_ieee = zigpy.types.EUI64(src_ieee)
         if ember_ieee not in self.devices:
             LOGGER.debug('New Device')
-            self.handle_join(src_nwk, ember_ieee, 0)  # TODO: Parent nwk        
-        device = self.get_device(ember_ieee)        
+            self.handle_join(src_nwk, ember_ieee, 0)  # TODO: Parent nwk       
+        device = self.get_device(ember_ieee)
         if device.nwk != src_nwk:
             LOGGER.debug('nwk changed')
             self.handle_join(src_nwk, ember_ieee, 0)

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -135,7 +135,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if device.nwk != src_nwk:
             LOGGER.debug('nwk changed')
             self.handle_join(src_nwk, ember_ieee, 0)
-            self._devices_by_nwk.pop(src_nwk, None)
+            self._devices_by_nwk.pop(device.nwk, None)
         self._devices_by_nwk[src_nwk] = src_ieee
 
         try:

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -130,12 +130,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         ember_ieee = zigpy.types.EUI64(src_ieee)
         if ember_ieee not in self.devices:
             LOGGER.debug('New Device')
-            self.handle_join(src_nwk, ember_ieee, 0)  # TODO: Parent nwk
-        self._devices_by_nwk[src_nwk] = src_ieee
-        device = self.get_device(ember_ieee)
+            self.handle_join(src_nwk, ember_ieee, 0)  # TODO: Parent nwk        
+        device = self.get_device(ember_ieee)        
         if device.nwk != src_nwk:
             LOGGER.debug('nwk changed')
             self.handle_join(src_nwk, ember_ieee, 0)
+            self._devices_by_nwk.pop(src_nwk, None)
+        self._devices_by_nwk[src_nwk] = src_ieee
 
         try:
             tsn, command_id, is_reply, args = self.deserialize(device, src_ep, cluster_id, data)


### PR DESCRIPTION
When the nwk of an existing device in the registry changes, handle_join isn't called.  This ensures that handle_join is called when the nwk is changed and that the old entry is removed and replaced.  Similar PR in zigpy: https://github.com/zigpy/bellows/commit/4cf12375111f3333d04c00159b07b0b004cc0538#diff-a03328e8d311484ecec5cd5f4129ab49