### PR TITLE
Handle initialization of the legacy S2 module

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from zigpy.types import EUI64
-from zigpy_xbee.api import XBee
+from zigpy_xbee.api import ModemStatus, XBee
 from zigpy_xbee.zigbee.application import ControllerApplication
 
 
@@ -14,11 +14,10 @@ def app(database_file=None):
 
 
 def test_modem_status(app):
-    assert 0x00 in app._api.MODEM_STATUS
-    app.handle_modem_status(0x00)
-    # assert that the test below actually checks a value that is not in MODEM_STATUS
-    assert 0xff not in app._api.MODEM_STATUS
-    app.handle_modem_status(0xff)
+    assert 0x00 in ModemStatus.__members__.values()
+    app.handle_modem_status(ModemStatus(0x00))
+    assert 0xEE not in ModemStatus.__members__.values()
+    app.handle_modem_status(ModemStatus(0xEE))
 
 
 def _test_rx(app, device, deserialized):
@@ -104,24 +103,56 @@ def test_rx_failed_deserialize(app, caplog):
 
 
 @pytest.mark.asyncio
+async def test_get_association_state(app):
+    ai_results = (0xff, 0xff, 0xff, 0xff, mock.sentinel.ai)
+    app._api._at_command = mock.MagicMock(
+        spec=XBee._at_command, side_effect=asyncio.coroutine(mock.MagicMock(
+            side_effect=ai_results
+        )))
+    ai = await app._get_association_state()
+    assert app._api._at_command.call_count == len(ai_results)
+    assert ai is mock.sentinel.ai
+
+
+@pytest.mark.asyncio
 async def test_form_network(app):
+    legacy_module = False
+
     async def mock_at_command(cmd, *args):
         if cmd == 'MY':
             return 0x0000
+        elif cmd == 'WR':
+            app._api.coordinator_started_event.set()
+        elif cmd == 'CE' and legacy_module:
+            raise RuntimeError
         return None
 
     app._api._at_command = mock.MagicMock(spec=XBee._at_command,
                                           side_effect=mock_at_command)
     app._api._queued_at = mock.MagicMock(spec=XBee._at_command,
                                          side_effect=mock_at_command)
+    app._get_association_state = mock.MagicMock(
+        spec=ControllerApplication._get_association_state,
+        side_effect=asyncio.coroutine(mock.MagicMock(return_value=0x00))
+    )
+
     await app.form_network()
     assert app._api._at_command.call_count >= 1
-    assert app._api._queued_at.call_count >= 10
+    assert app._api._queued_at.call_count >= 7
+    assert app._nwk == 0x0000
+
+    app._api._at_command.reset_mock()
+    app._api._queued_at.reset_mock()
+    legacy_module = True
+    await app.form_network()
+    assert app._api._at_command.call_count >= 1
+    assert app._api._queued_at.call_count >= 7
     assert app._nwk == 0x0000
 
 
 async def _test_startup(app, ai_status=0xff, auto_form=False, api_mode=True,
-                        api_config_succeeds=True):
+                        api_config_succeeds=True, ee=1, eo=2, zs=2,
+                        legacy_module=False):
     ai_tries = 5
     app._nwk = mock.sentinel.nwk
 
@@ -129,11 +160,15 @@ async def _test_startup(app, ai_status=0xff, auto_form=False, api_mode=True,
         nonlocal ai_tries
         if not api_mode:
             raise asyncio.TimeoutError
+        if cmd == 'CE' and legacy_module:
+            raise RuntimeError
 
         ai_tries -= 1 if cmd == 'AI' else 0
         return {
             'AI': ai_status if ai_tries < 0 else 0xff,
             'CE': 1 if ai_status == 0 else 0,
+            'EO': eo,
+            'EE': ee,
             'ID': mock.sentinel.at_id,
             'MY': 0xfffe if ai_status else 0x0000,
             'NJ': mock.sentinel.at_nj,
@@ -141,6 +176,7 @@ async def _test_startup(app, ai_status=0xff, auto_form=False, api_mode=True,
             'OP': mock.sentinel.at_op,
             'SH': 0x01020304,
             'SL': 0x05060708,
+            'ZS': zs,
         }.get(cmd, None)
 
     app._api._at_command = mock.MagicMock(spec=XBee._at_command,
@@ -184,6 +220,24 @@ async def test_startup_ai(app):
     assert app._nwk == 0xfffe
     assert app._ieee == EUI64(range(1, 9))
     assert app.form_network.call_count == 0
+
+    auto_form = True
+    await _test_startup(app, 0x00, auto_form, zs=1)
+    assert app._nwk == 0x0000
+    assert app._ieee == EUI64(range(1, 9))
+    assert app.form_network.call_count == 1
+
+    auto_form = False
+    await _test_startup(app, 0x06, auto_form, legacy_module=True)
+    assert app._nwk == 0xfffe
+    assert app._ieee == EUI64(range(1, 9))
+    assert app.form_network.call_count == 0
+
+    auto_form = True
+    await _test_startup(app, 0x00, auto_form, zs=1, legacy_module=True)
+    assert app._nwk == 0x0000
+    assert app._ieee == EUI64(range(1, 9))
+    assert app.form_network.call_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,3 +1,4 @@
+import pytest
 from zigpy_xbee import types as t
 
 
@@ -10,7 +11,8 @@ def test_deserialize():
     assert rest == extra
     assert result[0] == 0xff
     assert result[1] == -2
-    assert result[2] == t.EUI64((0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37))
+    assert result[2] == t.EUI64((0x30, 0x31, 0x32, 0x33,
+                                 0x34, 0x35, 0x36, 0x37))
 
 
 def test_serialize():
@@ -40,3 +42,32 @@ def test_atcommand():
 
     assert r_cmd == cmd
     assert r_data == data
+
+
+def test_undefined_enum_undefined_value():
+    class undEnum(t.uint8_t, t.UndefinedEnum):
+        OK = 0
+        ERROR = 2
+        UNDEFINED_VALUE = 0xff
+        _UNDEFINED = 0xff
+
+    i = undEnum(0)
+    assert i == 0
+    assert i.name == 'OK'
+
+    i = undEnum(2)
+    assert i == 2
+    assert i.name == 'ERROR'
+
+    i = undEnum(0xEE)
+    assert i.name == 'UNDEFINED_VALUE'
+
+
+def test_undefined_enum_undefinede():
+    class undEnum(t.uint8_t, t.UndefinedEnum):
+        OK = 0
+        ERROR = 2
+        UNDEFINED_VALUE = 0xff
+
+    with pytest.raises(ValueError):
+        undEnum(0xEE)

--- a/zigpy_xbee/api.py
+++ b/zigpy_xbee/api.py
@@ -350,10 +350,10 @@ class XBee:
 
         for cmd in cmds:
             if await self.command_mode_at_cmd(cmd + '\r'):
-                    LOGGER.debug("Successfuly sent %s cmd", cmd)
+                LOGGER.debug("Successfuly sent %s cmd", cmd)
             else:
-                    LOGGER.debug("No response to %s cmd", cmd)
-                    return None
+                LOGGER.debug("No response to %s cmd", cmd)
+                return None
         return True
 
     async def init_api_mode(self):

--- a/zigpy_xbee/api.py
+++ b/zigpy_xbee/api.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 
+from zigpy.types import LVList
+
 from . import uart
 from . import types as t
 
@@ -28,7 +30,7 @@ COMMANDS = {
     'rx_io_data_long_addr': (0x92, (), None),
     'remote_at_response': (0x97, (), None),
     'extended_status': (0x98, (), None),
-    'route_record_indicator': (0xA1, (), None),
+    'route_record_indicator': (0xA1, (t.EUI64, t.uint16_t, t.uint8_t, LVList(t.uint16_t)), None),
     'many_to_one_rri': (0xA3, (), None),
     'node_id_indicator': (0x95, (), None),
 
@@ -254,6 +256,10 @@ class XBee:
     def _handle_explicit_rx_indicator(self, data):
         LOGGER.debug("_handle_explicit_rx: opts=%s", data[6])
         self._app.handle_rx(*data)
+
+    def _handle_route_record_indicator(self, data):
+        """Handle Route Record indicator from a device."""
+        LOGGER.debug("_handle_route_record_indicator: %s", data)
 
     def _handle_tx_status(self, data):
         LOGGER.debug("tx_status: %s", data)

--- a/zigpy_xbee/types.py
+++ b/zigpy_xbee/types.py
@@ -128,3 +128,22 @@ class EUI64(zigpy.types.EUI64):
     def serialize(self):
         assert self._length == len(self)
         return b''.join([i.serialize() for i in self])
+
+
+class UndefinedEnumMeta(enum.EnumMeta):
+    def __call__(cls, value=None, *args, **kwargs):
+        if value is None:
+            # the 1st enum member is default
+            return next(iter(cls))
+
+        try:
+            return super().__call__(value, *args, **kwargs)
+        except ValueError as exc:
+            try:
+                return super().__call__(cls._UNDEFINED)
+            except AttributeError:
+                raise exc
+
+
+class UndefinedEnum(enum.Enum, metaclass=UndefinedEnumMeta):
+    pass

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -135,7 +135,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._api._at_command('CB', 2)
 
     def handle_modem_status(self, status):
-        LOGGER.info("Modem status update: %s (%s)", self._api.MODEM_STATUS.get(status, 'Unknown'), status)
+        LOGGER.info("Modem status update: %s (%s)", status.name, status.value)
 
     def handle_rx(self, src_ieee, src_nwk, src_ep, dst_ep, cluster_id, profile_id, rxopts, data):
         if src_nwk == 0:


### PR DESCRIPTION
Fixes #23 and https://github.com/zigpy/zigpy-xbee/issues/22#issuecomment-453878521

S2B and older modules do not support `ATCE1` command. If device replies with `ERROR` to ATCE1 command, make it a soft failure.