### PR TITLE
If ieee is generic, attempt look up by nwk

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -42,9 +42,9 @@ def _test_rx(app, device, nwk, deserialized,
 
 
 def _test_rx_ieee_generic(app, device, nwk, deserialized,
-             dst_ep=mock.sentinel.dst_ep,
-             cluster_id=mock.sentinel.cluster_id,
-             data=b''):
+                          dst_ep=mock.sentinel.dst_ep,
+                          cluster_id=mock.sentinel.cluster_id,
+                          data=b''):
     app.get_device = mock.MagicMock(return_value=device)
     app.deserialize = mock.MagicMock(return_value=deserialized)
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -41,6 +41,27 @@ def _test_rx(app, device, nwk, deserialized,
     assert app.deserialize.call_count == 1
 
 
+def _test_rx_ieee_generic(app, device, nwk, deserialized,
+             dst_ep=mock.sentinel.dst_ep,
+             cluster_id=mock.sentinel.cluster_id,
+             data=b''):
+    app.get_device = mock.MagicMock(return_value=device)
+    app.deserialize = mock.MagicMock(return_value=deserialized)
+
+    app.handle_rx(
+        b'\xff\xff\xff\xff\xff\xff\xff\xff',
+        nwk,
+        mock.sentinel.src_ep,
+        dst_ep,
+        cluster_id,
+        mock.sentinel.profile_id,
+        mock.sentinel.rxopts,
+        data,
+    )
+
+    assert app.deserialize.call_count == 1
+
+
 def test_rx(app):
     device = mock.MagicMock()
     app.handle_message = mock.MagicMock()

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -175,7 +175,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         try:
             if ember_ieee == zigpy.types.EUI64(b'\xff\xff\xff\xff\xff\xff\xff\xff'):
-                LOGGER.debug("Device reports a generic ieee, looking up by nwk")
                 device = self.get_device(nwk=src_nwk)
             else:
                 device = self.get_device(ieee=ember_ieee)

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -170,7 +170,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             self.handle_join(nwk, ieee, 0)
 
         try:
-            device = self.get_device(ieee=ember_ieee)
+            if ember_ieee == zigpy.types.EUI64(b'\xff\xff\xff\xff\xff\xff\xff\xff'):
+                LOGGER.debug("Device reports a generic ieee, looking up by nwk")
+                device = self.get_device(nwk=src_nwk)
+            else:
+                device = self.get_device(ieee=ember_ieee)
         except KeyError:
             LOGGER.debug("Received frame from unknown device: 0x%04x/%s",
                          src_nwk, str(ember_ieee))


### PR DESCRIPTION
Xiamoi devices will report a generic ieee if they are joined, this will cause them to be seen as an a new un-joined device when HA is restarted.  This change will attempt to look up the device by nwk if the ieee is generic.