### PR TITLE
treat TXStatus.SELF_ADDRESSED as a successful tramsmission.

### DIFF
--- a/zigpy_xbee/api.py
+++ b/zigpy_xbee/api.py
@@ -342,8 +342,9 @@ class XBee:
             return
 
         try:
-            if tx_status in (t.TXStatus.SUCCESS,
-                             t.TXStatus.BROADCAST_APS_TX_ATTEMPT):
+            if tx_status in (t.TXStatus.BROADCAST_APS_TX_ATTEMPT,
+                             t.TXStatus.SELF_ADDRESSED,
+                             t.TXStatus.SUCCESS):
                 fut.set_result(tx_status)
             else:
                 fut.set_exception(


### PR DESCRIPTION
Transmission Status of `TXStatus.SELF_ADDRESSED` is a successful transmission so treat it as such.