### PR TITLE
Dynamic reply timeout.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(exclude=['*.tests']),
     install_requires=[
         'pyserial-asyncio',
-        'zigpy-homeassistant',
+        'zigpy-homeassistant >= 0.3.3',
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
Tell Zigbee stack to use Extended Timeout between retries when communicating with an End Device.
Use longer reply timeout if far end is an End Device.