### PR TITLE
Disable APS encryption.

### DIFF
--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -204,7 +204,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         """
         LOGGER.debug("Zigbee request tsn #%s: %s", sequence, binascii.hexlify(data))
 
-        tx_opts = 0x20
+        tx_opts = 0x00
         if expect_reply and device.node_desc.is_end_device in (True, None):
             tx_opts |= 0x40
         send_req = self._api.tx_explicit(

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -331,7 +331,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             cluster,
             profile,
             radius,
-            0x20,
+            0x00,
             data,
         )
         try:


### PR DESCRIPTION
Disable APS encryption, as some devices do not support it and ATM `bellows` doesn't do APS encryption by default.
Fixes #30 
