### PR TITLE
Use correct broadcast EUI64

### DIFF
--- a/zigpy_xbee/types.py
+++ b/zigpy_xbee/types.py
@@ -160,7 +160,7 @@ class NWK(uint16_t):
     def __str__(self):
         return "0x{:04x}".format(self)
 
-
+BROADCAST_IEEE = EUI64.convert("00:00:00:00:00:00:FF:FF")
 UNKNOWN_IEEE = EUI64([uint8_t(0xFF) for i in range(0, 8)])
 UNKNOWN_NWK = NWK(0xFFFE)
 

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -11,7 +11,7 @@ import zigpy.util
 from zigpy.zcl.clusters.general import Groups
 from zigpy.zdo.types import NodeDescriptor, ZDOCmd
 
-from zigpy_xbee.types import EUI64, TXStatus, UNKNOWN_IEEE, UNKNOWN_NWK
+from zigpy_xbee.types import EUI64, TXStatus, BROADCAST_IEEE, UNKNOWN_IEEE, UNKNOWN_NWK
 
 
 # how long coordinator would hold message for an end device in 10ms units
@@ -171,7 +171,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         LOGGER.debug("Zigbee request tsn #%s: %s", sequence, binascii.hexlify(data))
 
         send_req = self._api.tx_explicit(
-            UNKNOWN_IEEE, group_id, src_ep, src_ep, cluster, profile, hops, 0x08, data
+            BROADCAST_IEEE, group_id, src_ep, src_ep, cluster, profile, hops, 0x08, data
         )
 
         try:


### PR DESCRIPTION
I was noticing that ZHA's zha.issue_zigbee_group_command wasn't working for the groups I had previously defined. Turns out there's some conflicting information in Digi's documentation on what EUI64 to set for multicast requests.

As per https://www.digi.com/resources/documentation/Digidocs/90002002/Default.htm#Reference/r_frame_0x11.htm%3FTocPath%3DFrame%2520descriptions%7C_____4 only 0x000000000000FFFF (Broadcast), 0x0000000000000000 (Coordinator) and an explicit EUI64 are allowed.

https://www.digi.com/resources/documentation/Digidocs/90002002/Default.htm#Concepts/c_zb_multicast_trans.htm%3FTocPath%3DTransmission%252C%2520addressing%252C%2520and%2520routing%7C_____4 indicates, and this is what zigpy-xbee does, to use 0xFFFFFFFFFFFFFFFF

Long story short. After changing the value to 0x00...FFFF it started working for me on an XSTICK2.

After the change:
```
2020-02-08 17:35:54 DEBUG (MainThread) [zigpy_xbee.zigbee.application] Zigbee request tsn #127: b'017f02'
2020-02-08 17:35:54 DEBUG (MainThread) [zigpy_xbee.api] Command tx_explicit (ff:ff:ff:ff:ff:ff:ff:ff, 0x0001, 1, 1, 6, 260, 0, 8, b'\x01\x7f\x02')
2020-02-08 17:35:54 DEBUG (MainThread) [zigpy_xbee.uart] Sending: b'\x11\xaa\xff\xff\xff\xff\xff\xff\xff\xff\x00\x01\x01\x01\x00\x06\x01\x04\x00\x08\x01\x7f\x02'
2020-02-08 17:35:54 DEBUG (MainThread) [zigpy_xbee.uart] Frame received: b'\x91\x00\x13\xa2\x00AXK\x11\x00\x00\x01\x01\x00\x06\x01\x04\x01\x01\x7f\x02'
2020-02-08 17:35:54 DEBUG (MainThread) [zigpy_xbee.api] Frame received: explicit_rx_indicator
2020-02-08 17:35:54 DEBUG (MainThread) [zigpy_xbee.api] _handle_explicit_rx: (00:13:a2:00:41:58:4b:11, 0x0000, 1, 6, 1, b'017f02')
2020-02-08 17:35:54 INFO (MainThread) [zigpy_xbee.zigbee.application] handle_rx self addressed
2020-02-08 17:35:54 DEBUG (MainThread) [zigpy.device] Ignoring message (b'017f02') on cluster 6: unknown endpoint or cluster id: 1
2020-02-08 17:35:54 DEBUG (MainThread) [zigpy_xbee.uart] Frame received: b'\x8b\xaa\x00\x00\x00\x00\x00'
2020-02-08 17:35:54 DEBUG (MainThread) [zigpy_xbee.api] Frame received: tx_status
2020-02-08 17:35:54 DEBUG (MainThread) [zigpy_xbee.api] tx_explicit to 0x0000: TXStatus.SUCCESS after 0 tries. Discovery Status: DiscoveryStatus.SUCCESS, Frame #170
2020-02-08 17:35:54 DEBUG (MainThread) [homeassistant.components.zha.api] Issued group command for: cluster_id: [6] command: [2] args: [] manufacturer: [None] response: (<TXStatus.SUCCESS: 0>, 'Successfully sent tsn #%s: %s')
```
