### PR TITLE
Bump up dependencies on pyserial and pyserial-asyncio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     author_email="rcloran@gmail.com",
     license="GPL-3.0",
     packages=find_packages(exclude=["*.tests"]),
-    install_requires=["pyserial-asyncio", "zigpy>= 0.23.0"],
+    install_requires=["pyserial==3.5", "pyserial-asyncio==0.5", "zigpy>= 0.23.0"],
     tests_require=["pytest"],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     author_email="rcloran@gmail.com",
     license="GPL-3.0",
     packages=find_packages(exclude=["*.tests"]),
-    install_requires=["pyserial==3.5", "pyserial-asyncio==0.5", "zigpy>= 0.23.0"],
+    install_requires=["pyserial>=3.5", "pyserial-asyncio>=0.5", "zigpy>= 0.23.0"],
     tests_require=["pytest"],
 )


### PR DESCRIPTION
Bump up dependencies on pyserial and pyserial-asyncio for projects other projects that use this library but are not Home Assistant.

Adminiuga did the same dependency version bump for Home Assistant in https://github.com/home-assistant/core/pull/44089

pyserial-asyncio depends on pyserial and this bumps pyserial-asyncio to 0.5 version release and pyserial to 3.5 version release.

https://github.com/pyserial/pyserial-asyncio/releases/tag/v0.5

https://github.com/pyserial/pyserial/releases/tag/v3.5