### PR TITLE
Adjust NodeDescriptor & fix hanging ZHA

### DIFF
--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -108,8 +108,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         dev = zigpy.device.Device(self, self.ieee, self.nwk)
         dev.status = zigpy.device.Status.ENDPOINTS_INIT
         dev.add_endpoint(XBEE_ENDPOINT_ID)
-        self.listener_event("raw_device_initialized", dev)
         xbee_dev = XBeeCoordinator(self, self.ieee, self.nwk, dev)
+        self.listener_event("raw_device_initialized", xbee_dev)
         self.devices[dev.ieee] = xbee_dev
 
     async def force_remove(self, dev):

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -381,7 +381,7 @@ class XBeeCoordinator(zigpy.quirks.CustomDevice):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.node_desc = NodeDescriptor(
-            0x01, 0x40, 0x8E, 0x101E, 0x52, 0x00FF, 0x2C00, 0x00FF, 0x00
+            0x00, 0x40, 0x8E, 0x101E, 0x52, 0x00FF, 0x2C00, 0x00FF, 0x00
         )
 
     replacement = {


### PR DESCRIPTION
- NodeDescriptor is set to "Router" but it should reflect the requirement "Zigbee Coordinator API firmware".
- Issue raw_device_initialized after xbee_dev is available; otherwise https://github.com/zigpy/zigpy/blob/dev/zigpy/appdb.py#L385 is not satisfied leaving an uncommited INSERT hanging around which leads to blocking ZHA & malfunction after restart (missing device) in SQLite 