### PR TITLE
Fix Remote AT command options

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -502,7 +502,7 @@ def test_remote_at_cmd(app, device):
     assert app._api._remote_at_command.call_count == 1
     assert app._api._remote_at_command.call_args[0][0] is dev.ieee
     assert app._api._remote_at_command.call_args[0][1] == s.nwk
-    assert app._api._remote_at_command.call_args[0][2] == 0x22
+    assert app._api._remote_at_command.call_args[0][2] == 0x12
     assert app._api._remote_at_command.call_args[0][3] == s.cmd
     assert app._api._remote_at_command.call_args[0][4] == s.data
 

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -254,7 +254,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if apply_changes:
             options |= 0x02
         if encryption:
-            options |= 0x20
+            options |= 0x10
         dev = self.get_device(nwk=nwk)
         return self._api._remote_at_command(dev.ieee, nwk, options, cmd_name, *args)
 


### PR DESCRIPTION
May be I am missing something, but the specs says that "Send the remote command securely" is Bit 4 [0x10].