### PR TITLE
Fix travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
-matrix:
+os: linux
+dist: focal
+cache: pip
+jobs:
   fast_finish: true
   include:
     - python: "3.7"


### PR DESCRIPTION
Not sure if travis ci is used or not, but this PR fixes it.
Note that tox for py37 still fails, but that's a different issue (probably py37 test should be obsolete)