### PR TITLE
Bump minimum zigpy version to 0.56.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(
     author_email="rcloran@gmail.com",
     license="GPL-3.0",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    install_requires=["zigpy>=0.51.0"],
+    install_requires=["zigpy>=0.56.0"],
     tests_require=["pytest", "asynctest", "pytest-asyncio"],
 )

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -263,7 +263,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 f"Failed to deliver packet: {v!r}", status=v
             )
 
-    @zigpy.util.retryable_request
+    @zigpy.util.retryable_request()
     def remote_at_command(
         self, nwk, cmd_name, *args, apply_changes=True, encryption=True
     ):


### PR DESCRIPTION
There was a syntax change with the `retryable_request` decorator in zigpy 0.56.0