### PR TITLE
Channel energy scan

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -603,12 +603,11 @@ async def test_energy_scan(app):
     rssi = b"\x0A\x0F\x14\x19\x1E\x23\x28\x2D\x32\x37\x3C\x41\x46\x4B\x50\x55"
     app._api._at_command = mock.AsyncMock(spec=XBee._at_command, return_value=rssi)
     time_s = 3
+    count = 3
     energy = await app.energy_scan(
-        channels=[x for x in range(11, 27)], duration_exp=time_s, count=3
+        channels=[x for x in range(11, 27)], duration_exp=time_s, count=count
     )
-    assert app._api._at_command.call_count == 3
-    assert app._api._at_command.call_args_list[0][0][0] == "ED"
-    assert app._api._at_command.call_args_list[0][0][1] == time_s
+    assert app._api._at_command.mock_calls == [mock.call("ED", time_s)] * count
     assert {k: round(v, 3) for k, v in energy.items()} == {
         11: 254.032,
         12: 253.153,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -597,3 +597,39 @@ async def test_move_network_to_channel(app):
 
     assert len(app._api._queued_at.mock_calls) == 1
     app._api._queued_at.assert_any_call("SC", 1 << (26 - 11))
+
+
+async def test_energy_scan(app):
+    async def mock_at_command(cmd, *args):
+        if cmd == "ED":
+            return b"\x0A\x0F\x14\x19\x1E\x23\x28\x2D\x32\x37\x3C\x41\x46\x4B\x50\x55"
+
+        return None
+
+    app._api._at_command = mock.MagicMock(
+        spec=XBee._at_command, side_effect=mock_at_command
+    )
+    time_s = 300
+    energy = await app.energy_scan(
+        channels=[x for x in range(11, 27)], duration_exp=time_s, count=3
+    )
+    assert app._api._at_command.call_count == 3
+    assert app._api._at_command.call_args_list[0][0][1] == time_s
+    assert {k: round(v, 3) for k, v in energy.items()} == {
+        11: 254.032,
+        12: 253.153,
+        13: 251.486,
+        14: 248.352,
+        15: 242.562,
+        16: 232.193,
+        17: 214.619,
+        18: 187.443,
+        19: 150.853,
+        20: 109.797,
+        21: 72.172,
+        22: 43.571,
+        23: 24.769,
+        24: 13.56,
+        25: 7.264,
+        26: 3.844,
+    }

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -600,20 +600,14 @@ async def test_move_network_to_channel(app):
 
 
 async def test_energy_scan(app):
-    async def mock_at_command(cmd, *args):
-        if cmd == "ED":
-            return b"\x0A\x0F\x14\x19\x1E\x23\x28\x2D\x32\x37\x3C\x41\x46\x4B\x50\x55"
-
-        return None
-
-    app._api._at_command = mock.MagicMock(
-        spec=XBee._at_command, side_effect=mock_at_command
-    )
-    time_s = 300
+    rssi = b"\x0A\x0F\x14\x19\x1E\x23\x28\x2D\x32\x37\x3C\x41\x46\x4B\x50\x55"
+    app._api._at_command = mock.AsyncMock(spec=XBee._at_command, return_value=rssi)
+    time_s = 3
     energy = await app.energy_scan(
         channels=[x for x in range(11, 27)], duration_exp=time_s, count=3
     )
     assert app._api._at_command.call_count == 3
+    assert app._api._at_command.call_args_list[0][0][0] == "ED"
     assert app._api._at_command.call_args_list[0][0][1] == time_s
     assert {k: round(v, 3) for k, v in energy.items()} == {
         11: 254.032,

--- a/zigpy_xbee/api.py
+++ b/zigpy_xbee/api.py
@@ -216,6 +216,8 @@ AT_COMMANDS = {
     "D7": t.uint8_t,  # 0 - 7 (an Enum)
     "P3": t.uint8_t,  # 0 - 5 (an Enum)
     "P4": t.uint8_t,  # 0 - 5 (an Enum)
+    # MAC diagnostics commands
+    "ED": t.Bytes,  # 16-byte value
     # I/O commands
     "IR": t.uint16_t,
     "IC": t.uint16_t,

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
+import statistics
 import time
 from typing import Any
 
@@ -181,15 +183,41 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         self, channels: zigpy.types.Channels, duration_exp: int, count: int
     ) -> dict[int, float]:
         """Runs an energy detection scan and returns the per-channel scan results."""
+        all_results = {}
 
-        if duration_exp:
-            energy = await self._api._at_command("ED", duration_exp)
-        else:
-            energy = await self._api._at_command("ED")
+        for _ in range(count):
+            if duration_exp:
+                results = await self._api._at_command("ED", duration_exp)
+            else:
+                results = await self._api._at_command("ED")
+            results = {
+                channel: -int(rssi) for channel, rssi in zip(range(11, 27), results)
+            }
 
-        energy = {c: -int(e) for c, e in zip(range(11, 27), energy)}
+            for channel, rssi in results.items():
+                all_results.setdefault(channel, []).append(rssi)
 
-        return {c: energy.get(c, 0) for c in channels}
+        def logistic(x: float, *, L: float = 1, x_0: float = 0, k: float = 1) -> float:
+            """Logistic function."""
+            return L / (1 + math.exp(-k * (x - x_0)))
+
+        def map_rssi_to_energy(rssi: int) -> float:
+            """Remaps RSSI (in dBm) to Energy (0-255)."""
+            RSSI_MAX = -5
+            RSSI_MIN = -92
+            return logistic(
+                x=rssi,
+                L=255,
+                x_0=RSSI_MIN + 0.45 * (RSSI_MAX - RSSI_MIN),
+                k=0.13,
+            )
+
+        energy = {
+            channel: map_rssi_to_energy(statistics.mean(all_rssi))
+            for channel, all_rssi in all_results.items()
+        }
+
+        return {channel: energy.get(channel, 0) for channel in channels}
 
     async def force_remove(self, dev):
         """Forcibly remove device from NCP."""

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -186,10 +186,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         all_results = {}
 
         for _ in range(count):
-            if duration_exp:
-                results = await self._api._at_command("ED", duration_exp)
-            else:
-                results = await self._api._at_command("ED")
+            results = await self._api._at_command("ED", duration_exp)
             results = {
                 channel: -int(rssi) for channel, rssi in zip(range(11, 27), results)
             }

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -182,8 +182,14 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     ) -> dict[int, float]:
         """Runs an energy detection scan and returns the per-channel scan results."""
 
-        LOGGER.warning("Coordinator does not support energy scanning")
-        return {c: 0 for c in channels}
+        if duration_exp:
+            energy = await self._api._at_command("ED", duration_exp)
+        else:
+            energy = await self._api._at_command("ED")
+
+        energy = {c: -int(e) for c, e in zip(range(11, 27), energy)}
+
+        return {c: energy.get(c, 0) for c in channels}
 
     async def force_remove(self, dev):
         """Forcibly remove device from NCP."""


### PR DESCRIPTION
Add support for per-channel energy detect for XBee coordinators.

Logs:
```
2023-09-26 09:05:26.779 DEBUG (MainThread) [zigpy_xbee.api] at command: ED (4,)
2023-09-26 09:05:26.779 DEBUG (MainThread) [zigpy_xbee.api] Command at (b'ED', b'\x00\x00\x00\x00')
2023-09-26 09:05:26.779 DEBUG (MainThread) [zigpy_xbee.uart] Sending: b'\x08\x14ED\x00\x00\x00\x00'
2023-09-26 09:05:27.153 DEBUG (MainThread) [homeassistant.bootstrap] Running timeout Zones: {'xbee_humidifier': <xbee_humidifier: 0 / 1>}
2023-09-26 09:05:27.154 DEBUG (MainThread) [homeassistant.bootstrap] Integration remaining: {'zha': 14.551212}
2023-09-26 09:05:27.467 DEBUG (MainThread) [zigpy_xbee.uart] Frame received: b'\x88\x14ED\x00/D1>\x06"\x16.*90IEKK7'
2023-09-26 09:05:27.467 DEBUG (MainThread) [zigpy_xbee.api] Frame received: at_response
2023-09-26 09:05:27.478 DEBUG (MainThread) [zigpy.application] Startup energy scan: {11: -47, 12: -68, 13: -49, 14: -62, 15: -6, 16: -34, 17: -22, 18: -46, 19: -42, 20: -57, 21: -48, 22: -73, 23: -69, 24: -75, 25: -75, 26: -55}
```

Prtially implements #112 though it is not a stand-alone tool.