### PR TITLE
Joining with link key

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -416,6 +416,26 @@ def test_handle_tx_status_duplicate(api):
     assert send_fut.set_exception.call_count == 0
 
 
+def test_handle_registration_status(api):
+    frame_id = 0x12
+    status = xbee_api.RegistrationStatus.SUCCESS
+    fut = asyncio.Future()
+    api._awaiting[frame_id] = (fut,)
+    api._handle_registration_status(frame_id, status)
+    assert fut.done() is True
+    assert fut.result() == xbee_api.RegistrationStatus.SUCCESS
+    assert fut.exception() is None
+
+    frame_id = 0x13
+    status = xbee_api.RegistrationStatus.KEY_TABLE_IS_FULL
+    fut = asyncio.Future()
+    api._awaiting[frame_id] = (fut,)
+    api._handle_registration_status(frame_id, status)
+    assert fut.done() is True
+    with pytest.raises(RuntimeError, match="Registration Status: KEY_TABLE_IS_FULL"):
+        fut.result()
+
+
 async def test_command_mode_at_cmd(api):
     command = "+++"
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -413,6 +413,19 @@ async def test_permit(app):
     assert app._api._at_command.call_args_list[0][0][1] == time_s
 
 
+async def test_permit_with_key(app):
+    app._api._command = mock.AsyncMock(return_value=xbee_t.TXStatus.SUCCESS)
+    app._api._at_command = mock.AsyncMock(return_value="OK")
+    node = t.EUI64(b"\x01\x02\x03\x04\x05\x06\x07\x08")
+    code = "C9A7D2441A711695CD62170D3328EA2B423D"
+    time_s = 500
+    await app.permit_with_key(node=node, code=code, time_s=time_s)
+    app._api._at_command.assert_called_once_with("KT", time_s)
+    app._api._command.assert_called_once_with(
+        "register_joining_device", node, 0xFFFE, 1, code
+    )
+
+
 async def _test_request(
     app, expect_reply=True, send_success=True, send_timeout=False, **kwargs
 ):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -417,12 +417,25 @@ async def test_permit_with_key(app):
     app._api._command = mock.AsyncMock(return_value=xbee_t.TXStatus.SUCCESS)
     app._api._at_command = mock.AsyncMock(return_value="OK")
     node = t.EUI64(b"\x01\x02\x03\x04\x05\x06\x07\x08")
-    code = "C9A7D2441A711695CD62170D3328EA2B423D"
+    code = b"\xC9\xA7\xD2\x44\x1A\x71\x16\x95\xCD\x62\x17\x0D\x33\x28\xEA\x2B\x42\x3D"
     time_s = 500
     await app.permit_with_key(node=node, code=code, time_s=time_s)
     app._api._at_command.assert_called_once_with("KT", time_s)
     app._api._command.assert_called_once_with(
         "register_joining_device", node, 0xFFFE, 1, code
+    )
+
+
+async def test_permit_with_link_key(app):
+    app._api._command = mock.AsyncMock(return_value=xbee_t.TXStatus.SUCCESS)
+    app._api._at_command = mock.AsyncMock(return_value="OK")
+    node = t.EUI64(b"\x01\x02\x03\x04\x05\x06\x07\x08")
+    link_key = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"
+    time_s = 500
+    await app.permit_with_link_key(node=node, link_key=link_key, time_s=time_s)
+    app._api._at_command.assert_called_once_with("KT", time_s)
+    app._api._command.assert_called_once_with(
+        "register_joining_device", node, 0xFFFE, 0, link_key
     )
 
 

--- a/zigpy_xbee/api.py
+++ b/zigpy_xbee/api.py
@@ -572,11 +572,9 @@ class XBee:
     def _handle_registration_status(self, frame_id, status):
         (fut,) = self._awaiting.pop(frame_id)
         if status:
-            fut.set_exception(
-                RuntimeError("Registration Status: {}".format(status.name))
-            )
+            fut.set_exception(RuntimeError(f"Registration Status: {status.name}"))
             return
-        LOGGER.debug("Registration Status: {}".format(status.name))
+        LOGGER.debug(f"Registration Status: {status.name}")
 
         fut.set_result(status)
 

--- a/zigpy_xbee/api.py
+++ b/zigpy_xbee/api.py
@@ -89,6 +89,20 @@ class ModemStatus(t.uint8_t, t.UndefinedEnum):
     _UNDEFINED = 0xFF
 
 
+class RegistrationStatus(t.uint8_t, t.UndefinedEnum):
+    SUCCESS = 0x00
+    KEY_TOO_LONG = 0x01
+    TRANSIENT_KEY_TABLE_IS_FULL = 0x18
+    ADDRESS_NOT_FOUND_IN_THE_KEY_TABLE = 0xB1
+    KEY_IS_INVALID_OR_RESERVED = 0xB2
+    INVALID_ADDRESS = 0xB3
+    KEY_TABLE_IS_FULL = 0xB4
+    SECURITY_DATA_IS_INVALID_INSTALL_CODE_CRC_FAILS = 0xBD
+
+    UNKNOWN_MODEM_STATUS = 0xFF
+    _UNDEFINED = 0xFF
+
+
 # https://www.digi.com/resources/documentation/digidocs/PDFs/90000976.pdf
 COMMAND_REQUESTS = {
     "at": (0x08, (t.FrameId, t.ATCommand, t.Bytes), 0x88),
@@ -120,7 +134,11 @@ COMMAND_REQUESTS = {
         (t.FrameId, t.EUI64, t.NWK, t.uint8_t, t.Relays),
         None,
     ),
-    "register_joining_device": (0x24, (), None),
+    "register_joining_device": (
+        0x24,
+        (t.FrameId, t.EUI64, t.uint16_t, t.uint8_t, t.Bytes),
+        0xA4,
+    ),
 }
 COMMAND_RESPONSES = {
     "at_response": (0x88, (t.FrameId, t.ATCommand, t.uint8_t, t.Bytes), None),
@@ -155,6 +173,7 @@ COMMAND_RESPONSES = {
     "extended_status": (0x98, (), None),
     "route_record_indicator": (0xA1, (t.EUI64, t.NWK, t.uint8_t, t.Relays), None),
     "many_to_one_rri": (0xA3, (t.EUI64, t.NWK, t.uint8_t), None),
+    "registration_status": (0xA4, (t.FrameId, RegistrationStatus), None),
     "node_id_indicator": (0x95, (), None),
 }
 
@@ -201,6 +220,7 @@ AT_COMMANDS = {
     "EO": t.uint8_t,
     "NK": t.Bytes,  # 128-bit value
     "KY": t.Bytes,  # 128-bit value
+    "KT": t.uint16_t,  # 0x1E - 0xFFFF
     # RF interfacing commands
     "PL": t.uint8_t,  # 0 - 4 (basically an Enum)
     "PM": t.Bool,
@@ -548,6 +568,17 @@ class XBee:
                 fut.set_exception(DeliveryError(f"{tx_status}"))
         except asyncio.InvalidStateError as ex:
             LOGGER.debug("duplicate tx_status for %s nwk? State: %s", nwk, ex)
+
+    def _handle_registration_status(self, frame_id, status):
+        (fut,) = self._awaiting.pop(frame_id)
+        if status:
+            fut.set_exception(
+                RuntimeError("Registration Status: {}".format(status.name))
+            )
+            return
+        LOGGER.debug("Registration Status: {}".format(status.name))
+
+        fut.set_result(status)
 
     def set_application(self, app):
         self._app = app

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -319,8 +319,14 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._api._at_command("NJ", time_s)
         await self._api._at_command("AC")
 
-    async def permit_with_key(self, node, code, time_s=60):
-        raise NotImplementedError("XBee does not support install codes")
+    async def permit_with_key(self, node: EUI64, code: bytes, time_s=500, key_type=1):
+        assert 0x1E <= time_s <= 0xFFFF
+        await self._api._at_command("KT", time_s)
+        reserved = 0xFFFE
+        # Key type:
+        # 0 = Pre-configured Link Key (KY command of the joining device)
+        # 1 = Install Code With CRC (I? command of the joining device)
+        await self._api.register_joining_device(node, reserved, key_type, code)
 
     def handle_modem_status(self, status):
         LOGGER.info("Modem status update: %s (%s)", status.name, status.value)

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -319,14 +319,21 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._api._at_command("NJ", time_s)
         await self._api._at_command("AC")
 
-    async def permit_with_key(self, node: EUI64, code: bytes, time_s=500, key_type=1):
+    async def permit_with_link_key(
+        self, node: EUI64, link_key: zigpy.types.KeyData, time_s: int = 500, key_type=0
+    ):
+        """Permits a new device to join with the given IEEE and link key."""
         assert 0x1E <= time_s <= 0xFFFF
         await self._api._at_command("KT", time_s)
         reserved = 0xFFFE
         # Key type:
         # 0 = Pre-configured Link Key (KY command of the joining device)
         # 1 = Install Code With CRC (I? command of the joining device)
-        await self._api.register_joining_device(node, reserved, key_type, code)
+        await self._api.register_joining_device(node, reserved, key_type, link_key)
+
+    async def permit_with_key(self, node: EUI64, code: bytes, time_s=500):
+        """Permits a new device to join with the given IEEE and Install Code."""
+        await self.permit_with_link_key(node, code, time_s, key_type=1)
 
     def handle_modem_status(self, status):
         LOGGER.info("Modem status update: %s (%s)", status.name, status.value)


### PR DESCRIPTION
Add support for device joining via install codes.

Successful logs:
```
INFO (MainThread) [homeassistant.helpers.script.websocket_api_script] websocket_api script: Running websocket_api script
INFO (MainThread) [homeassistant.helpers.script.websocket_api_script] websocket_api script: Executing step call service
DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=zha, service=permit, service_data=duration=60, install_code=C9A7D2441A711695CD62170D3328EA2B423D, source_ieee=0013A200419823F9>
INFO (MainThread) [homeassistant.components.zha.websocket_api] Allowing join for 00:13:a2:00:41:98:23:f9 device with install code
DEBUG (MainThread) [zigpy_xbee.api] at command: KT (60,)
DEBUG (MainThread) [zigpy_xbee.api] Command at (b'KT', b'\x00<')
DEBUG (MainThread) [zigpy_xbee.uart] Sending: b'\x082KT\x00<'
DEBUG (MainThread) [zigpy_xbee.uart] Frame received: b'\x882KT\x00'
DEBUG (MainThread) [zigpy_xbee.api] Frame received: at_response
DEBUG (MainThread) [zigpy_xbee.api] Command register_joining_device (00:13:a2:00:41:98:23:f9, 65534, 1, b'\xc9\xa7\xd2D\x1aq\x16\x95\xcdb\x17\r3(\xea+B=')
DEBUG (MainThread) [zigpy_xbee.uart] Sending: b'$3\x00\x13\xa2\x00A\x98#\xf9\xff\xfe\x01\xc9\xa7\xd2D\x1aq\x16\x95\xcdb\x17\r3(\xea+B='
DEBUG (MainThread) [zigpy_xbee.uart] Frame received: b'\xa43\x00'
DEBUG (MainThread) [zigpy_xbee.api] Frame received: registration_status
DEBUG (MainThread) [zigpy_xbee.api] Registration Status: SUCCESS
```
Unsuccessful logs (invalid IEEE provided):
```
INFO [homeassistant.helpers.script.websocket_api_script] websocket_api script: Running websocket_api script
INFO [homeassistant.helpers.script.websocket_api_script] websocket_api script: Executing step call service
DEBUG [homeassistant.core] Bus:Handling <Event call_service[L]: domain=zha, service=permit, service_data=duration=60, source_ieee=0000000000000000, install_code=C9A7D2441A711695CD62170D3328EA2B423D>
INFO [homeassistant.components.zha.websocket_api] Allowing join for 00:00:00:00:00:00:00:00 device with install code
DEBUG [zigpy_xbee.api] at command: KT (60,)
DEBUG [zigpy_xbee.api] Command at (b'KT', b'\x00<')
DEBUG [zigpy_xbee.uart] Sending: b'\x085KT\x00<'
DEBUG [zigpy_xbee.uart] Frame received: b'\x885KT\x00'
DEBUG [zigpy_xbee.api] Frame received: at_response
DEBUG [zigpy_xbee.api] Command register_joining_device (00:00:00:00:00:00:00:00, 65534, 1, b'\xc9\xa7\xd2D\x1aq\x16\x95\xcdb\x17\r3(\xea+B=')
DEBUG [zigpy_xbee.uart] Sending: b'$6\x00\x00\x00\x00\x00\x00\x00\x00\xff\xfe\x01\xc9\xa7\xd2D\x1aq\x16\x95\xcdb\x17\r3(\xea+B='
DEBUG [zigpy_xbee.uart] Frame received: b'\xa46\xb3'
DEBUG [zigpy_xbee.api] Frame received: registration_status
ERROR [homeassistant.helpers.script.websocket_api_script] websocket_api script: Error executing script. Unexpected error for call_service at pos 1: Registration Status: INVALID_ADDRESS
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.11/site-packages/homeassistant/helpers/script.py", line 468, in _async_step
    await getattr(self, handler)()
  File "/srv/homeassistant/lib/python3.11/site-packages/homeassistant/helpers/script.py", line 704, in _async_call_service_step
    response_data = await self._async_run_long_action(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/homeassistant/lib/python3.11/site-packages/homeassistant/helpers/script.py", line 666, in _async_run_long_action
    return long_task.result()
           ^^^^^^^^^^^^^^^^^^
  File "/srv/homeassistant/lib/python3.11/site-packages/homeassistant/core.py", line 1969, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/srv/homeassistant/lib/python3.11/site-packages/homeassistant/core.py", line 2006, in _execute_service
    return await target(service_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/homeassistant/lib/python3.11/site-packages/homeassistant/helpers/service.py", line 980, in admin_handler
    await result
  File "/srv/homeassistant/lib/python3.11/site-packages/homeassistant/components/zha/websocket_api.py", line 1256, in permit
    await application_controller.permit_with_key(
  File "/srv/homeassistant/lib/python3.11/site-packages/zigpy_xbee/zigbee/application.py", line 304, in permit_with_key
    await self._api.register_joining_device(node, reserved, key_type, code)
RuntimeError: Registration Status: INVALID_ADDRESS
```