### PR TITLE
Don't fail on energy scan with legacy modules

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -734,7 +734,7 @@ async def test_energy_scan(app):
 async def test_energy_scan_legacy_module(app):
     """Test channel energy scan."""
     app._api._at_command = mock.AsyncMock(
-        spec=XBee._at_command, side_effect=RuntimeError
+        spec=XBee._at_command, side_effect=InvalidCommand
     )
     time_s = 3
     count = 3

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -731,6 +731,20 @@ async def test_energy_scan(app):
     }
 
 
+async def test_energy_scan_legacy_module(app):
+    """Test channel energy scan."""
+    app._api._at_command = mock.AsyncMock(
+        spec=XBee._at_command, side_effect=RuntimeError
+    )
+    time_s = 3
+    count = 3
+    energy = await app.energy_scan(
+        channels=list(range(11, 27)), duration_exp=time_s, count=count
+    )
+    app._api._at_command.assert_called_once_with("ED", bytes([time_s]))
+    assert energy == {c: 0 for c in range(11, 27)}
+
+
 def test_neighbors_updated(app, device):
     """Test LQI from neighbour scan."""
     router = device(ieee=b"\x01\x02\x03\x04\x05\x06\x07\x08")

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -197,7 +197,12 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         all_results = {}
 
         for _ in range(count):
-            results = await self._api._at_command("ED", bytes([duration_exp]))
+            try:
+                results = await self._api._at_command("ED", bytes([duration_exp]))
+            except RuntimeError:
+                LOGGER.warning("Coordinator does not support energy scanning")
+                return {c: 0 for c in channels}
+
             results = {
                 channel: -int(rssi) for channel, rssi in zip(range(11, 27), results)
             }

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -199,7 +199,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         for _ in range(count):
             try:
                 results = await self._api._at_command("ED", bytes([duration_exp]))
-            except RuntimeError:
+            except InvalidCommand:
                 LOGGER.warning("Coordinator does not support energy scanning")
                 return {c: 0 for c in channels}
 


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/103208

If we receive the `RuntimeError` exeption on `ED` command, return zero energy scanning results instead of raising the exception.