### PR TITLE
Fix energy scan duraton

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -709,7 +709,7 @@ async def test_energy_scan(app):
     energy = await app.energy_scan(
         channels=list(range(11, 27)), duration_exp=time_s, count=count
     )
-    assert app._api._at_command.mock_calls == [mock.call("ED", time_s)] * count
+    assert app._api._at_command.mock_calls == [mock.call("ED", bytes([time_s]))] * count
     assert {k: round(v, 3) for k, v in energy.items()} == {
         11: 254.032,
         12: 253.153,

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -196,7 +196,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         all_results = {}
 
         for _ in range(count):
-            results = await self._api._at_command("ED", duration_exp)
+            results = await self._api._at_command("ED", bytes([duration_exp]))
             results = {
                 channel: -int(rssi) for channel, rssi in zip(range(11, 27), results)
             }


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/103208
Supersedes #166

The S2C modules do support energy scan:
https://www.digi.com/resources/documentation/digidocs/90002002/default.htm#Reference/r_cmd_ED.htm?TocPath=AT%2520commands%257CNetwork%2520commands%257C_____17

The difference with XBee3 is the parameter range: S2C accepts 0x01-0xFF or no parameter, while XBee3 accepts 0x00-0xFF. In other words, to use a default parameter value one need to pass no parameters for S2C and 0x00 for XBee3.

Due to a bug we are sending the parameter as `b'\x00\x00\x00\x00'` instead of `b'\x04'` for 4 ms, the XBee3 firmware accepts that parameter as default, while S2C firmware returns an `INVALD_PARAMETER` response.

The bug is because we implicitly used `bytes()` constructor with an integer argument, that returns an array of zeros. Using `[duration_exp]` or `bytes([duration_exp])` instead of `duration_exp` resolves the issue.