### PR TITLE
Disable watchdog

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -866,11 +866,3 @@ async def test_routes_updated(app, device):
     assert router2.radio_details.call_count == 0
 
     app._api._at_command.assert_awaited_once_with("DB")
-
-
-async def test_watchdog(app):
-    """Test watchdog feed method."""
-    app._api._at_command = mock.AsyncMock(return_value="OK")
-    await app._watchdog_feed()
-
-    assert app._api._at_command.mock_calls == [mock.call("VR")]

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -51,9 +51,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         self._api: zigpy_xbee.api.XBee | None = None
         self.topology.add_listener(self)
 
-    async def _watchdog_feed(self):
-        await self._api._at_command("VR")
-
     async def disconnect(self):
         """Shutdown application."""
         if self._api:


### PR DESCRIPTION
See #171.

I think we should disable the watchdog for XBee until a solution is found, as the library did not previously use a watchdog so no functionality is lost.