### PR TITLE
Limit request concurrency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "GPL-3.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "zigpy>=0.60.0",
+    "zigpy>=0.60.2",
 ]
 
 [tool.setuptools.packages.find]

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -302,7 +302,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 "Cannot send a packet to a device without a known IEEE address"
             )
 
-        send_req = self._api.tx_explicit(
+        send_req = self._api._command(
+            "tx_explicit",
             long_addr,
             short_addr,
             packet.src_ep or 0,
@@ -356,7 +357,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         # Key type:
         # 0 = Pre-configured Link Key (KY command of the joining device)
         # 1 = Install Code With CRC (I? command of the joining device)
-        await self._api.register_joining_device(node, reserved, key_type, link_key)
+        await self._api._command(
+            "register_joining_device", node, reserved, key_type, link_key
+        )
 
     def handle_modem_status(self, status):
         """Handle changed Modem Status of the device."""

--- a/zigpy_xbee/zigbee/application.py
+++ b/zigpy_xbee/zigbee/application.py
@@ -302,30 +302,31 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 "Cannot send a packet to a device without a known IEEE address"
             )
 
-        send_req = self._api._command(
-            "tx_explicit",
-            long_addr,
-            short_addr,
-            packet.src_ep or 0,
-            packet.dst_ep or 0,
-            packet.cluster_id,
-            packet.profile_id,
-            packet.radius,
-            tx_opts,
-            packet.data.serialize(),
-        )
-
-        try:
-            v = await asyncio.wait_for(send_req, timeout=TIMEOUT_TX_STATUS)
-        except asyncio.TimeoutError:
-            raise zigpy.exceptions.DeliveryError(
-                "Timeout waiting for ACK", status=TXStatus.NETWORK_ACK_FAILURE
+        async with self._limit_concurrency():
+            send_req = self._api._command(
+                "tx_explicit",
+                long_addr,
+                short_addr,
+                packet.src_ep or 0,
+                packet.dst_ep or 0,
+                packet.cluster_id,
+                packet.profile_id,
+                packet.radius,
+                tx_opts,
+                packet.data.serialize(),
             )
 
-        if v != TXStatus.SUCCESS:
-            raise zigpy.exceptions.DeliveryError(
-                f"Failed to deliver packet: {v!r}", status=v
-            )
+            try:
+                v = await asyncio.wait_for(send_req, timeout=TIMEOUT_TX_STATUS)
+            except asyncio.TimeoutError:
+                raise zigpy.exceptions.DeliveryError(
+                    "Timeout waiting for ACK", status=TXStatus.NETWORK_ACK_FAILURE
+                )
+
+            if v != TXStatus.SUCCESS:
+                raise zigpy.exceptions.DeliveryError(
+                    f"Failed to deliver packet: {v!r}", status=v
+                )
 
     @zigpy.util.retryable_request()
     def remote_at_command(


### PR DESCRIPTION
Zigpy provides a way for radio libraries to limit request concurrency (by default 8). It seems like zigpy-xbee did not use it. You can increase/decrease the default via YAML:

```yaml
zha:
  zigpy_config:
    max_concurrent_requests: 8  
```

@Shulyaka this may actually be the only change required for zigpy-xbee to work properly with the watchdog. If you can find a value that works well for your XBee, this may supersede #172.